### PR TITLE
Include oauth_body_hash parameter in outcome request.

### DIFF
--- a/dce_lti_py/outcome_request.py
+++ b/dce_lti_py/outcome_request.py
@@ -136,7 +136,8 @@ class OutcomeRequest():
                 'OutcomeRequest does not have all required attributes')
 
         header_oauth = OAuth1(self.consumer_key, self.consumer_secret,
-                       signature_type=SIGNATURE_TYPE_AUTH_HEADER, **kwargs)
+                       signature_type=SIGNATURE_TYPE_AUTH_HEADER,
+                       force_include_body=True, **kwargs)
 
         headers = {'Content-type': 'application/xml'}
         resp = requests.post(self.lis_outcome_service_url, auth=header_oauth,

--- a/tests/test_outcome_request.py
+++ b/tests/test_outcome_request.py
@@ -127,6 +127,6 @@ class TestOutcomeRequest(unittest.TestCase):
             'oauth_nonce="my_nonce", oauth_timestamp="1234567890", '
             'oauth_version="1.0", oauth_signature_method="HMAC-SHA1", '
             'oauth_consumer_key="consumer", '
-            'oauth_signature="rbvjzAHwXPs/e41Runtu6w9Gv+w="')
+            'oauth_body_hash="glWvnsZZ8lMif1ATz8Tx64CTTaY=", '
+            'oauth_signature="XR6A1CmUauXZdJZXa1pJpTQi6OQ="')
         self.assertEqual(auth_header, correct)
-


### PR DESCRIPTION
Moodle will not accept outcome requests without oauth_body_hash.
